### PR TITLE
ARQ-124 Move jndi.properties out as configuration

### DIFF
--- a/containers/jbossas-managed-6/src/main/java/org/jboss/arquillian/container/jbossas/managed_6/JBossASConfiguration.java
+++ b/containers/jbossas-managed-6/src/main/java/org/jboss/arquillian/container/jbossas/managed_6/JBossASConfiguration.java
@@ -36,12 +36,15 @@ public class JBossASConfiguration implements ContainerConfiguration
 
    private String profileName = "default";
    
-   // 
    private String jbossHome = System.getenv("JBOSS_HOME");
    
    private String javaHome = System.getenv("JAVA_HOME");
    
    private String javaVmArguments = "-Xmx512m -XX:MaxPermSize=128m";
+
+   // default to ERROR to ensure a fast start, though let it be configurable
+   // might need to look into this more because both server.log and output.log are being written
+   private String logThreshold = "ERROR";
 
    public ContainerProfile getContainerProfile()
    {
@@ -122,5 +125,15 @@ public class JBossASConfiguration implements ContainerConfiguration
    public String getJavaVmArguments()
    {
       return javaVmArguments;
+   }
+
+   public String getLogThreshold()
+   {
+      return logThreshold;
+   }
+
+   public void setLogThreshold(String logThreshold)
+   {
+      this.logThreshold = logThreshold;
    }
 }

--- a/containers/jbossas-managed-6/src/main/java/org/jboss/arquillian/container/jbossas/managed_6/JBossASLocalContainer.java
+++ b/containers/jbossas-managed-6/src/main/java/org/jboss/arquillian/container/jbossas/managed_6/JBossASLocalContainer.java
@@ -77,7 +77,7 @@ public class JBossASLocalContainer implements DeployableContainer
             throw new LifecycleException(
             		"The server is already running! " +
             		"Managed containers does not support connecting to running server instances due to the " +
-            		"possible harmfull effect of connecting to the wrong server. Please stop server before running or " +
+            		"possible harmful effect of connecting to the wrong server. Please stop server before running or " +
             		"change to another type of container.");
          }
          
@@ -237,7 +237,7 @@ public class JBossASLocalContainer implements DeployableContainer
       server.setName(configuration.getProfileName());
       server.setHttpPort(configuration.getHttpPort());
       server.setHost(configuration.getBindAddress());
-      
+      server.setLogThreshold(configuration.getLogThreshold());
       server.setUsername("admin");
       server.setPassword("admin");
       server.setPartition(Long.toHexString(System.currentTimeMillis()));

--- a/containers/jbossas-remote-5.1/src/main/java/org/jboss/arquillian/container/jbossas/remote_5_1/JBossASConfiguration.java
+++ b/containers/jbossas-remote-5.1/src/main/java/org/jboss/arquillian/container/jbossas/remote_5_1/JBossASConfiguration.java
@@ -44,6 +44,13 @@ public class JBossASConfiguration implements ContainerConfiguration
     * Used by Servlet Protocol to connect to deployment.
     */
    private int remoteServerHttpPort = 8080;
+   
+   /**
+    * Port on which the JBoss Naming Service is running. Used to lookup objects
+    * in JNDI and invoke MBean operations. Combined with remoteServerAddress to
+    * create the JNDI provider URL (e.g., jnp://localhost:1099)
+    */
+   private int remoteServerNamingServicePort = 1099;
 
    /**
     * Bind Address for HTTP server for serving deployments to the remote server.
@@ -90,6 +97,16 @@ public class JBossASConfiguration implements ContainerConfiguration
    public void setRemoteServerHttpPort(int remoteServerHttpPort)
    {
       this.remoteServerHttpPort = remoteServerHttpPort;
+   }
+   
+   public int getRemoteServerNamingServicePort()
+   {
+      return remoteServerNamingServicePort;
+   }
+   
+   public void setRemoteServerNamingServicePort(int remoteServerNamingServicePort)
+   {
+      this.remoteServerNamingServicePort = remoteServerNamingServicePort;
    }
    
    public String getLocalDeploymentBindAddress()

--- a/containers/jbossas-remote-5/src/main/java/org/jboss/arquillian/container/jbossas/remote_5_0/JBossASConfiguration.java
+++ b/containers/jbossas-remote-5/src/main/java/org/jboss/arquillian/container/jbossas/remote_5_0/JBossASConfiguration.java
@@ -44,6 +44,13 @@ public class JBossASConfiguration implements ContainerConfiguration
     * Used by Servlet Protocol to connect to deployment.
     */
    private int remoteServerHttpPort = 8080;
+   
+   /**
+    * Port on which the JBoss Naming Service is running. Used to lookup objects
+    * in JNDI and invoke MBean operations. Combined with remoteServerAddress to
+    * create the JNDI provider URL (e.g., jnp://localhost:1099)
+    */
+   private int remoteServerNamingServicePort = 1099;
 
    /**
     * Bind Address for HTTP server for serving deployments to the remote server.
@@ -90,6 +97,16 @@ public class JBossASConfiguration implements ContainerConfiguration
    public void setRemoteServerHttpPort(int remoteServerHttpPort)
    {
       this.remoteServerHttpPort = remoteServerHttpPort;
+   }
+   
+   public int getRemoteServerNamingServicePort()
+   {
+      return remoteServerNamingServicePort;
+   }
+   
+   public void setRemoteServerNamingServicePort(int remoteServerNamingServicePort)
+   {
+      this.remoteServerNamingServicePort = remoteServerNamingServicePort;
    }
    
    public String getLocalDeploymentBindAddress()

--- a/containers/jbossas-remote-5/src/main/java/org/jboss/arquillian/container/jbossas/remote_5_0/JBossASRemoteContainer.java
+++ b/containers/jbossas-remote-5/src/main/java/org/jboss/arquillian/container/jbossas/remote_5_0/JBossASRemoteContainer.java
@@ -51,7 +51,12 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 /**
- * JbossRemoteContainer
+ * A {@link DeployableContainer} implementation for a remote JBoss AS 6.x instance.
+ *
+ * <p>As is true of all remote container types, this implementation assumes that
+ * the container is already running. The connection properties are defined by
+ * the type {@link JBossASConfiguration} in this same package and configured
+ * via XML.</p>
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
  * @version $Revision: $
@@ -214,13 +219,21 @@ public class JBossASRemoteContainer implements DeployableContainer
 
    private void initDeploymentManager() throws Exception 
    {
-      String profileName = configuration.getProfileName();
-      InitialContext ctx = new InitialContext();
-      ProfileService ps = (ProfileService) ctx.lookup("ProfileService");
+      ProfileService ps = (ProfileService) buildInitialContext().lookup("ProfileService");
       deploymentManager = ps.getDeploymentManager();
-      ProfileKey defaultKey = new ProfileKey(profileName);
+      ProfileKey defaultKey = new ProfileKey(configuration.getProfileName());
       deploymentManager.loadProfile(defaultKey, false);
       VFS.init();
+   }
+
+   private InitialContext buildInitialContext() throws Exception
+   {
+      InitialContext ctx = new InitialContext();
+      ctx.addToEnvironment(InitialContext.INITIAL_CONTEXT_FACTORY, "org.jnp.interfaces.NamingContextFactory");
+      ctx.addToEnvironment(InitialContext.URL_PKG_PREFIXES, "org.jboss.naming:org.jnp.interfaces");
+      ctx.addToEnvironment(InitialContext.PROVIDER_URL, "jnp://" +
+            configuration.getRemoteServerAddress() + ":" + configuration.getRemoteServerNamingServicePort());
+      return ctx;
    }
    
    private URL createFileServerURL(String archiveName) 
@@ -230,7 +243,7 @@ public class JBossASRemoteContainer implements DeployableContainer
          InetSocketAddress address = httpFileServer.getAddress();
          return new URL(
                "http", 
-               address.getHostName(), 
+               address.getHostName(), // this causes problem with avahi; returns hostname.local; prefer configuration.getLocalDeploymentBindAddress()
                address.getPort(), 
                "/" + archiveName);
       }

--- a/containers/jbossas-remote-6/src/main/java/org/jboss/arquillian/container/jbossas/remote_6/JBossASConfiguration.java
+++ b/containers/jbossas-remote-6/src/main/java/org/jboss/arquillian/container/jbossas/remote_6/JBossASConfiguration.java
@@ -44,6 +44,13 @@ public class JBossASConfiguration implements ContainerConfiguration
     * Used by Servlet Protocol to connect to deployment.
     */
    private int remoteServerHttpPort = 8080;
+   
+   /**
+    * Port on which the JBoss Naming Service is running. Used to lookup objects
+    * in JNDI and invoke MBean operations. Combined with remoteServerAddress to
+    * create the JNDI provider URL (e.g., jnp://localhost:1099)
+    */
+   private int remoteServerNamingServicePort = 1099;
 
    /**
     * Bind Address for HTTP server for serving deployments to the remote server.
@@ -90,6 +97,16 @@ public class JBossASConfiguration implements ContainerConfiguration
    public void setRemoteServerHttpPort(int remoteServerHttpPort)
    {
       this.remoteServerHttpPort = remoteServerHttpPort;
+   }
+   
+   public int getRemoteServerNamingServicePort()
+   {
+      return remoteServerNamingServicePort;
+   }
+   
+   public void setRemoteServerNamingServicePort(int remoteServerNamingServicePort)
+   {
+      this.remoteServerNamingServicePort = remoteServerNamingServicePort;
    }
    
    public String getLocalDeploymentBindAddress()

--- a/containers/jbossas-remote-6/src/main/java/org/jboss/arquillian/container/jbossas/remote_6/JBossASConfiguration.java
+++ b/containers/jbossas-remote-6/src/main/java/org/jboss/arquillian/container/jbossas/remote_6/JBossASConfiguration.java
@@ -44,6 +44,13 @@ public class JBossASConfiguration implements ContainerConfiguration
     * Used by Servlet Protocol to connect to deployment.
     */
    private int remoteServerHttpPort = 8080;
+   
+   /**
+    * Port on which the JBoss Naming Service is running. Used to lookup objects
+    * in JNDI and invoke MBean operations. Combined with remoteServerAddress to
+    * create the JNDI provider URL (e.g., jnp://localhost:1099)
+    */
+   private int remoteServerNamingServicePort = 1099;
 
    /**
     * Bind Address for HTTP server for serving deployments to the remote server.
@@ -56,6 +63,12 @@ public class JBossASConfiguration implements ContainerConfiguration
     * Port must be reachable from remote server.
     */
    private int localDeploymentBindPort = 9999;
+   
+   /**
+    * Port on which the JBoss Naming Service is running. Used to lookup
+    * objects in JNDI and invoke operations on MBeans.
+    */
+   private int remoteServerNamingServicePort = 1099;
    
    public ContainerProfile getContainerProfile()
    {
@@ -90,6 +103,16 @@ public class JBossASConfiguration implements ContainerConfiguration
    public void setRemoteServerHttpPort(int remoteServerHttpPort)
    {
       this.remoteServerHttpPort = remoteServerHttpPort;
+   }
+   
+   public int getRemoteServerNamingServicePort()
+   {
+      return remoteServerNamingServicePort;
+   }
+   
+   public void setRemoteServerNamingServicePort(int remoteServerNamingServicePort)
+   {
+      this.remoteServerNamingServicePort = remoteServerNamingServicePort;
    }
    
    public String getLocalDeploymentBindAddress()

--- a/containers/jbossas-remote-6/src/main/java/org/jboss/arquillian/container/jbossas/remote_6/JBossASRemoteContainer.java
+++ b/containers/jbossas-remote-6/src/main/java/org/jboss/arquillian/container/jbossas/remote_6/JBossASRemoteContainer.java
@@ -51,7 +51,12 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 /**
- * JbossRemoteContainer
+ * A {@link DeployableContainer} implementation for a remote JBoss AS 6.x instance.
+ *
+ * <p>As is true of all remote container types, this implementation assumes that
+ * the container is already running. The connection properties are defined by
+ * the type {@link JBossASConfiguration} in this same package and configured
+ * via XML.</p>
  *
  * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
  * @version $Revision: $
@@ -216,12 +221,20 @@ public class JBossASRemoteContainer implements DeployableContainer
 
    private void initDeploymentManager() throws Exception 
    {
-      String profileName = configuration.getProfileName();
-      InitialContext ctx = new InitialContext();
-      ProfileService ps = (ProfileService) ctx.lookup("ProfileService");
+      ProfileService ps = (ProfileService) buildInitialContext().lookup("ProfileService");
       deploymentManager = ps.getDeploymentManager();
-      ProfileKey defaultKey = new ProfileKey(profileName);
+      ProfileKey defaultKey = new ProfileKey(configuration.getProfileName());
       deploymentManager.loadProfile(defaultKey);
+   }
+
+   private InitialContext buildInitialContext() throws Exception
+   {
+      InitialContext ctx = new InitialContext();
+      ctx.addToEnvironment(InitialContext.INITIAL_CONTEXT_FACTORY, "org.jnp.interfaces.NamingContextFactory");
+      ctx.addToEnvironment(InitialContext.URL_PKG_PREFIXES, "org.jboss.naming:org.jnp.interfaces");
+      ctx.addToEnvironment(InitialContext.PROVIDER_URL, "jnp://" +
+            configuration.getRemoteServerAddress() + ":" + configuration.getRemoteServerNamingServicePort());
+      return ctx;
    }
    
    private URL createFileServerURL(String archiveName) 
@@ -231,7 +244,7 @@ public class JBossASRemoteContainer implements DeployableContainer
          InetSocketAddress address = httpFileServer.getAddress();
          return new URL(
                "http", 
-               address.getHostName(), 
+               address.getHostName(), // this causes problem with avahi; returns hostname.local; prefer configuration.getLocalDeploymentBindAddress()
                address.getPort(), 
                "/" + archiveName);
       }
@@ -295,15 +308,25 @@ public class JBossASRemoteContainer implements DeployableContainer
     */
    private void startDeploymentScanner() throws Exception
    {
-      ObjectName DEPLOYMNET_SCANNER = new ObjectName("jboss.deployment:flavor=URL,type=DeploymentScanner");
-      MBeanServerConnection adaptor = (MBeanServerConnection)new InitialContext().lookup("jmx/invoker/RMIAdaptor");
-      adaptor.invoke(DEPLOYMNET_SCANNER, "start", new Object[] {}, new String[]{});
+      invokeDeploymentScannerOperation("start");
    }
 
    private void stopDeploymentScanner() throws Exception
    {
-      ObjectName DEPLOYMNET_SCANNER = new ObjectName("jboss.deployment:flavor=URL,type=DeploymentScanner");
-      MBeanServerConnection adaptor = (MBeanServerConnection)new InitialContext().lookup("jmx/invoker/RMIAdaptor");
-      adaptor.invoke(DEPLOYMNET_SCANNER, "stop", new Object[] {}, new String[]{});
+      invokeDeploymentScannerOperation("stop");
+   }
+   
+   private void invokeDeploymentScannerOperation(String operation) throws Exception
+   {
+      if (operation == "start" || operation == "stop")
+      {
+         ObjectName DEPLOYMNET_SCANNER = new ObjectName("jboss.deployment:flavor=URL,type=DeploymentScanner");
+         MBeanServerConnection adaptor = (MBeanServerConnection) buildInitialContext().lookup("jmx/invoker/RMIAdaptor");
+         adaptor.invoke(DEPLOYMNET_SCANNER, operation, new Object[] {}, new String[]{});
+      }
+      else
+      {
+         throw new IllegalArgumentException("Unsupported deployment scanner operation for this context: " + operation);
+      }
    }
 }

--- a/containers/jetty-embedded-7/src/main/java/org/jboss/arquillian/container/jetty/embedded_7/JettyEmbeddedContainer.java
+++ b/containers/jetty-embedded-7/src/main/java/org/jboss/arquillian/container/jetty/embedded_7/JettyEmbeddedContainer.java
@@ -115,6 +115,7 @@ public class JettyEmbeddedContainer implements DeployableContainer
       {
          WebAppContext wctx = archive.as(ShrinkWrapWebAppContext.class);
          // Jetty plus is required to support in-container invocation and enrichment
+         // QUESTION is that true for Jetty 7, or is it just for @Resource injection?
          if (containerConfig.isJettyPlus())
          {
             wctx.setConfigurationClasses(JETTY_PLUS_CONFIGURATION_CLASSES);

--- a/doc/reference/src/main/docbook/en-US/containers.xml
+++ b/doc/reference/src/main/docbook/en-US/containers.xml
@@ -21,16 +21,28 @@
       <title>Container varieties</title>
 
       <para>
-         There are two styles of containers that you can target in Arquillian:
+         You can run the same test case against various containers with Arquillian. The test class does not reference
+         the container directly, which means you don't get locked into a proprietary test environment. It also means you
+         can select the optimal container for development or easily test the compatibility of your application.
+      </para>
+
+      <para>
+         Arquillian recognizes three container interaction styles:
       </para> 
 
       <orderedlist>
          <listitem>
-            <para>remote &#8212; resides in a separate JVM from the test runner; its lifecycle may be managed by Arquillian,
-            or Arquillian may bind to a container that is already started</para>
+            <para>a <emphasis>remote</emphasis> container resides in a separate JVM from the test runner; Arquillian binds to the container to
+            deploy and undeploy the test archive and invokes tests via a remote protocol (typically HTTP)</para>
          </listitem>
          <listitem>
-            <para>embedded &#8212; resides in the same JVM as the test runner; its lifecycle is likely managed by Arquillian</para>
+            <para>an <emphasis>embedded</emphasis> container resides in the same JVM as the test runner; lifecycle managed by Arquillian; tests
+            are executed via a local protocol for containers without a web component (e.g., Embedded EJB) and via a
+            remote protocol for containers that have a web component (e.g., Embedded Java EE)</para>
+         </listitem>
+         <listitem>
+            <para>a <emphasis>managed</emphasis> container is the same as a remote container, but in addition, its
+            lifecycle (startup/shutdown) is managed by Arquillian and is run as a separate process</para>
          </listitem>
       </orderedlist>
 
@@ -54,6 +66,27 @@
          Arquillian provides SPIs that handle each of the tasks involved in controlling the runtime environment,
          executing the tests and aggregating the results. So in theory, you can support just about any environment that
          can be controlled with the set of hooks you are given.
+      </para>
+
+   </section>
+
+   <section>
+      <title>Container management</title>
+
+      <para>
+         While the management of an <emphasis>embedded</emphasis> container is straightforward, you may wonder how
+         Arquillian knows where the remote and managed containers are installed. Actually, Arquillian only needs to know
+         the install path of <emphasis>managed</emphasis> containers (e.g., jbossas-managed-6). In this case, since
+         Arquillian manages the container process, it must have access to the container's startup script. For managed
+         JBoss AS containers, the install path is read from the environment variable JBOSS_HOME.
+      </para>
+
+      <para>
+         For <emphasis>remote</emphasis> containers (e.g., jbossas-remote-6), Arquillian simply needs to know that the
+         container is running and communicates with it using a remote protocol (e.g., JNDI). For remote JBoss AS
+         containers, the JNDI settings are set in a jndi.properties file on the classpath. You also have to set the
+         remote address and HTTP port in the container configuration if they differ from the default values (localhost
+         and 8080 for JBoss AS, respectively).
       </para>
 
    </section>

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,27 @@
   <!--  Profiles -->
   <profiles>
   
-    <!-- Build all Arquillian modules -->
+    <!-- Build essential Arquillian modules, quickier startup for newcomers -->
     <profile>
-      <id>all</id>
+      <id>essential</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <modules>
+        <module>build</module>
+        <module>api</module>
+        <module>spi</module>
+        <module>impl-base</module>
+        <module>junit</module>
+        <module>testng</module>
+        <module>testenrichers</module> 
+        <module>protocols</module>
+      </modules>
+    </profile>
+
+    <!-- Build all Arquillian modules and containers -->
+    <profile>
+      <id>all</id>
       <modules>
       
         <!-- Core -->
@@ -72,7 +87,7 @@
         
         <module>containers</module>
     
-	<module>extensions</module>
+        <module>extensions</module>
         <module>frameworks</module>
         <module>examples</module>
     

--- a/protocols/servlet-3/src/main/java/org/jboss/arquillian/protocol/servlet_3/ServletProtocolDeploymentPackager.java
+++ b/protocols/servlet-3/src/main/java/org/jboss/arquillian/protocol/servlet_3/ServletProtocolDeploymentPackager.java
@@ -83,22 +83,22 @@ public class ServletProtocolDeploymentPackager implements DeploymentPackager
 
    private Archive<?> handleArchive(JavaArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives, Archive<?> protocol) 
    {
-      WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war");
+      WebArchive war = ShrinkWrap.create(WebArchive.class, "test.war");
       if (applicationArchive.contains(EJB_JAR_XML_JAR_PATH))
       {
-         archive.add(applicationArchive.get(EJB_JAR_XML_JAR_PATH).getAsset(), EJB_JAR_XML_WAR_PATH);
+         war.add(applicationArchive.get(EJB_JAR_XML_JAR_PATH).getAsset(), EJB_JAR_XML_WAR_PATH);
          applicationArchive.delete(EJB_JAR_XML_JAR_PATH);
       }
       
       if (applicationArchive.contains(BEANS_XML_JAR_PATH))
       {
-         archive.add(applicationArchive.get(BEANS_XML_JAR_PATH).getAsset(), BEANS_XML_WAR_PATH);
+         war.add(applicationArchive.get(BEANS_XML_JAR_PATH).getAsset(), BEANS_XML_WAR_PATH);
          applicationArchive.delete(BEANS_XML_JAR_PATH);
       }
 
-      archive.addLibraries(applicationArchive, protocol);
-      archive.addLibraries(auxiliaryArchives.toArray(new Archive[0]));
-      return archive;
+      war.addLibraries(applicationArchive, protocol);
+      war.addLibraries(auxiliaryArchives.toArray(new Archive[0]));
+      return war;
    }
 
    private Archive<?> handleArchive(EnterpriseArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives, Archive<?> protocol) 

--- a/protocols/servlet-3/src/main/java/org/jboss/arquillian/protocol/servlet_3/ServletProtocolDeploymentPackager.java
+++ b/protocols/servlet-3/src/main/java/org/jboss/arquillian/protocol/servlet_3/ServletProtocolDeploymentPackager.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 import org.jboss.arquillian.spi.DeploymentPackager;
 import org.jboss.arquillian.spi.TestDeployment;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -34,6 +36,14 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  */
 public class ServletProtocolDeploymentPackager implements DeploymentPackager
 {
+   private static final ArchivePath EJB_JAR_XML_JAR_PATH = ArchivePaths.create("META-INF/ejb-jar.xml");
+
+   private static final ArchivePath EJB_JAR_XML_WAR_PATH = ArchivePaths.create("WEB-INF/ejb-jar.xml");
+
+   private static final ArchivePath BEANS_XML_JAR_PATH = ArchivePaths.create("META-INF/beans.xml");
+
+   private static final ArchivePath BEANS_XML_WAR_PATH = ArchivePaths.create("WEB-INF/beans.xml");
+
    /* (non-Javadoc)
     * @see org.jboss.arquillian.spi.DeploymentPackager#generateDeployment(org.jboss.arquillian.spi.TestDeployment)
     */
@@ -73,9 +83,22 @@ public class ServletProtocolDeploymentPackager implements DeploymentPackager
 
    private Archive<?> handleArchive(JavaArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives, Archive<?> protocol) 
    {
-         return ShrinkWrap.create(WebArchive.class, "test.war")
-                  .addLibraries(applicationArchive, protocol)
-                  .addLibraries(auxiliaryArchives.toArray(new Archive[0]));
+      WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war");
+      if (applicationArchive.contains(EJB_JAR_XML_JAR_PATH))
+      {
+         archive.add(applicationArchive.get(EJB_JAR_XML_JAR_PATH).getAsset(), EJB_JAR_XML_WAR_PATH);
+         applicationArchive.delete(EJB_JAR_XML_JAR_PATH);
+      }
+      
+      if (applicationArchive.contains(BEANS_XML_JAR_PATH))
+      {
+         archive.add(applicationArchive.get(BEANS_XML_JAR_PATH).getAsset(), BEANS_XML_WAR_PATH);
+         applicationArchive.delete(BEANS_XML_JAR_PATH);
+      }
+
+      archive.addLibraries(applicationArchive, protocol);
+      archive.addLibraries(auxiliaryArchives.toArray(new Archive[0]));
+      return archive;
    }
 
    private Archive<?> handleArchive(EnterpriseArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives, Archive<?> protocol) 

--- a/testenrichers/cdi/pom.xml
+++ b/testenrichers/cdi/pom.xml
@@ -24,7 +24,7 @@
 	<properties>
 
 		<!-- Versioning -->
-		<version.weld-core>1.0.0-SP4</version.weld-core>
+		<version.weld-core>1.0.1-SP4</version.weld-core>
 		<version.javax-el>2.2</version.javax-el>
 		<version.slf4j>1.5.9.RC1</version.slf4j>
 		


### PR DESCRIPTION
I figured out that all we need to do is set the following three JNDI properties whenever we create an InitialContext in the container implementation:

InitialContext.INITIAL_CONTEXT_FACTORY
InitialContext.URL_PKG_PREFIXES
InitialContext.PROVIDER_URL

99% of the time, the defaults will be fine for development. The only property that really needs customizing is the last one. And that's really just a matter of setting which port the naming service is run on. So, for now, I've just abstracted out the port into configuration and use the remoteServerAddress for the host.

jndi.properties be gone!
