### PR TITLE
Arq 299 - Exception Proxying

### DIFF
--- a/spi/src/main/java/org/jboss/arquillian/spi/ArquillianProxyException.java
+++ b/spi/src/main/java/org/jboss/arquillian/spi/ArquillianProxyException.java
@@ -1,0 +1,42 @@
+package org.jboss.arquillian.spi;
+
+public class ArquillianProxyException extends RuntimeException {
+
+	private static final long serialVersionUID = -4703822636139101499L;
+
+	public ArquillianProxyException() {
+		super();
+	}
+
+	public ArquillianProxyException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ArquillianProxyException(String message) {
+		super(message);
+	}
+
+	public ArquillianProxyException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * ArquillianProxyException constructor based on an underlying exception
+	 * that cannot be recreated.
+	 * 
+	 * @param message
+	 *            Message from the proxied Exception
+	 * @param exceptionClassName
+	 *            Class name of the proxied class type
+	 * @param reason
+	 *            reason that the exception couldn't be re-created
+	 * @param cause
+	 *            cause from the original exception
+	 */
+	public ArquillianProxyException(String message, String exceptionClassName,
+			String reason, Throwable cause) {
+		this(String.format("%s : %s [Proxied because : %s]", exceptionClassName,message, 
+				reason),cause);
+	}
+
+}

--- a/spi/src/main/java/org/jboss/arquillian/spi/ArquillianProxyException.java
+++ b/spi/src/main/java/org/jboss/arquillian/spi/ArquillianProxyException.java
@@ -1,5 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.arquillian.spi;
 
+/**
+ * Exception class used when a proxied exception cannot be created. This
+ * exception type is is thrown instead and contains information about the
+ * proxied class and a hint about why it could not be thrown.
+ * 
+ * @author <a href="mailto:contact@andygibson.net">Andy Gibson</a>
+ * 
+ */
 public class ArquillianProxyException extends RuntimeException {
 
 	private static final long serialVersionUID = -4703822636139101499L;

--- a/spi/src/main/java/org/jboss/arquillian/spi/ExceptionProxy.java
+++ b/spi/src/main/java/org/jboss/arquillian/spi/ExceptionProxy.java
@@ -1,3 +1,19 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jboss.arquillian.spi;
 
 import java.io.Serializable;
@@ -24,7 +40,7 @@ import java.lang.reflect.Constructor;
  * </ul>
  * 
  * 
- * @author Andy Gibson
+ * @author <a href="mailto:contact@andygibson.net">Andy Gibson</a>
  * 
  */
 public class ExceptionProxy implements Serializable {

--- a/spi/src/main/java/org/jboss/arquillian/spi/ExceptionProxy.java
+++ b/spi/src/main/java/org/jboss/arquillian/spi/ExceptionProxy.java
@@ -101,7 +101,6 @@ public class ExceptionProxy implements Serializable {
 	 * @return Instance of the Throwable class.
 	 */
 	private Throwable constructExceptionForClass(Class<?> clazz) {
-		System.out.println("Constructing object for class "+clazz+" With message "+message);
 		Object object = buildObjectFromClassConstructors(clazz);
 
 		if (object == null) {

--- a/spi/src/main/java/org/jboss/arquillian/spi/ExceptionProxy.java
+++ b/spi/src/main/java/org/jboss/arquillian/spi/ExceptionProxy.java
@@ -1,0 +1,213 @@
+package org.jboss.arquillian.spi;
+
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+
+/**
+ * Takes an exception class and creates a proxy that can be used to rebuild the
+ * exception. The problem stems from problems serializing exceptions and
+ * deserializing them in another application where the exception classes might
+ * not exist, or they might exist in different version. This proxy also
+ * propagates the stacktrace and the cause exception to create totally portable
+ * exceptions. </p> This class creates a serializable proxy of the exception and
+ * when unserialized can be used to re-create the exception based on the
+ * following rules :
+ * <ul>
+ * <li>If the exception class exists on the client, the original exception is
+ * created</li>
+ * <li>If the exception class exists, but doesn't have a suitable constructor
+ * then another exception is thrown referencing the original exception</li>
+ * <li>If the exception class exists, but is not throwable, another exception is
+ * thrown referencing the original exception</li>
+ * <li>If the exception class doesn't exist, another exception is raised instead
+ * </li>
+ * </ul>
+ * 
+ * 
+ * @author Andy Gibson
+ * 
+ */
+public class ExceptionProxy implements Serializable {
+
+	private static final long serialVersionUID = 2321010311438950147L;
+
+	private String className;
+	private String message;
+	private StackTraceElement[] trace;
+	private ExceptionProxy causeProxy;
+	private Throwable cause;
+
+	public ExceptionProxy(Throwable throwable) {
+		this.className = throwable.getClass().getName();
+		this.message = throwable.getMessage();
+		this.trace = throwable.getStackTrace();
+		this.causeProxy = ExceptionProxy.createForException(throwable
+				.getCause());
+	}
+
+	@Override
+	public String toString() {
+		return super.toString()
+				+ String.format("[class=%s, message=%s],cause = %s", className,
+						message, causeProxy);
+
+	}
+
+	/**
+	 * Indicates whether this proxy wraps an exception
+	 * 
+	 * @return Flag indicating an exception is wrapped.
+	 */
+	public boolean hasException() {
+		return className != null;
+	}
+
+	/**
+	 * Constructs an instance of the proxied exception based on the class name,
+	 * message, stack trace and if applicable, the cause.
+	 * 
+	 * @return The constructed {@link Throwable} instance
+	 */
+	public Throwable createException() {
+		if (!hasException()) {
+			return null;
+		}
+
+		Class<?> clazz = null;
+		try {
+			clazz = Class.forName(className);
+		} catch (ClassNotFoundException e) {
+			return createProxyException("Exception class not found on client");
+		}
+
+		Throwable throwable = constructExceptionForClass(clazz);
+		throwable.setStackTrace(trace);
+		return throwable;
+	}
+
+	public ArquillianProxyException createProxyException(String reason) {
+		return new ArquillianProxyException(message, className, reason,
+				getCause());
+	}
+
+	/**
+	 * Constructs an instance of the passed in class if a suitable constructor
+	 * is found. If the constructor subclasses {@link Throwable} it is returned.
+	 * If a Class instance is not constructed ot is not a {@link Throwable} then
+	 * another exception is returned indicating this.
+	 * 
+	 * @param clazz
+	 *            Class to construct
+	 * @return Instance of the Throwable class.
+	 */
+	private Throwable constructExceptionForClass(Class<?> clazz) {
+		System.out.println("Constructing object for class "+clazz+" With message "+message);
+		Object object = buildObjectFromClassConstructors(clazz);
+
+		if (object == null) {
+			return createProxyException("Could not find suitable constructor");
+		}
+
+		if (!(object instanceof Throwable)) {			
+			return createProxyException("Proxy references non-Throwable type");
+		}
+		return (Throwable) object;
+	}
+
+	private Object buildObjectFromClassConstructors(Class<?> clazz) {
+		// try the (String,Throwable) constructor first
+		Object object = buildExceptionFromConstructor(clazz, new Class<?>[] {
+				String.class, Throwable.class }, new Object[] { message,
+				getCause() });
+		if (object != null) {
+			return object;
+		}
+
+		// try the (String,Exception) constructor first
+		object = buildExceptionFromConstructor(clazz, new Class<?>[] {
+				String.class, Exception.class }, new Object[] { message,
+				getCause() });
+		if (object != null) {
+			return object;
+		}
+
+		// try the (String) constructor next
+		object = buildExceptionFromConstructor(clazz,
+				new Class<?>[] { String.class }, new Object[] { message });
+		if (object != null) {
+			return object;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Attempt to build an exception of the given class type using the
+	 * constructor signature and parameters passed in. If no constructor matches
+	 * or the constructor throws an exception, then null is returned.
+	 * 
+	 * @param clazz
+	 *            Class to construct
+	 * @param signature
+	 *            Array of class types to match the signature on
+	 * @param params
+	 *            Parameter values to pass to the constructor if found.
+	 * @return The object instance created using the constructor
+	 */
+	private <T> T buildExceptionFromConstructor(Class<T> clazz,
+			Class<?>[] signature, Object[] params) {
+		Constructor<?> constructor = null;
+		// try the message,cause constructor first
+		try {
+			constructor = clazz.getConstructor(signature);
+		} catch (SecurityException e) {
+			// we'll try the next signature
+		} catch (NoSuchMethodException e) {
+			// we'll try the next signature
+		}
+		// if we found a working constructor, use it
+		if (constructor != null) {
+			try {
+				@SuppressWarnings("unchecked")
+				T result = (T) constructor.newInstance(params);
+				return result;
+			} catch (Throwable e) {
+				return null;
+			}
+		}
+		// no matching constructor, no result
+		return null;
+
+	}
+
+	/**
+	 * Static method to create an exception proxy for the passed in
+	 * {@link Throwable} class. If null is passed in, null is returned as the
+	 * exception proxy
+	 * 
+	 * @param throwable
+	 *            Exception to proxy
+	 * @return An ExceptionProxy representing the exception passed in
+	 */
+	public static ExceptionProxy createForException(Throwable throwable) {
+		if (throwable == null) {
+			return null;
+		}
+		return new ExceptionProxy(throwable);
+	}
+
+	/**
+	 * Returns the cause of the exception represented by this proxy
+	 * 
+	 * @return The cause of this exception
+	 */
+	public Throwable getCause() {
+		// lazy create cause
+		if (cause == null) {
+			if (causeProxy != null) {
+				cause = causeProxy.createException();
+			}
+		}
+		return cause;
+	}
+}

--- a/spi/src/main/java/org/jboss/arquillian/spi/TestResult.java
+++ b/spi/src/main/java/org/jboss/arquillian/spi/TestResult.java
@@ -24,141 +24,146 @@ import java.io.Serializable;
  * 
  * @author Pete Muir
  * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
- *
+ * 
  */
-public class TestResult implements Serializable
-{
-   private static final long serialVersionUID = 1L;
+public final class TestResult implements Serializable {
+	private static final long serialVersionUID = 1L;
 
-   /**
-    * The test status
-    * @author Pete Muir
-    *
-    */
-   public enum Status
-   {
-      /**
-       * The test passed
-       */
-      PASSED,
-      /**
-       * The test failed
-       */
-      FAILED,
-      /**
-       * The test was skipped due to some deployment problem
-       */
-      SKIPPED;
-   }
+	/**
+	 * The test status
+	 * 
+	 * @author Pete Muir
+	 * 
+	 */
+	public enum Status {
+		/**
+		 * The test passed
+		 */
+		PASSED,
+		/**
+		 * The test failed
+		 */
+		FAILED,
+		/**
+		 * The test was skipped due to some deployment problem
+		 */
+		SKIPPED;
+	}
 
-   private Status status;
-   private Throwable throwable;
+	private Status status;
+	transient private Throwable throwable;
+	private ExceptionProxy exceptionProxy;
 
-   private long start;
-   private long end;
-   
-   /**
-    * Create a empty result.<br/> 
-    * <br/>
-    * Start time is set to Current Milliseconds.
-    */
-   public TestResult()
-   {
-      this(null);
-   }
-   
-   /**
-    * Create a new TestResult.<br/>
-    * <br/>
-    * Start time is set to Current Milliseconds.
-    * 
-    * @param status The result status.
-    */
-   public TestResult(Status status)
-   {
-      this(status, null);
-   }
-   
-   /**
-    * Create a new TestResult.<br/>
-    * <br/>
-    * Start time is set to Current Milliseconds.
-    * 
-    * @param status The result status.
-    * @param throwable thrown exception if any
-    */
-   public TestResult(Status status, Throwable throwable)
-   {
-      this.status = status;
-      this.throwable = throwable;
-      
-      this.start = System.currentTimeMillis();
-   }
+	private long start;
+	private long end;
 
-   /**
-    * Get the status of this test
-    */
-   public Status getStatus() 
-   {
-      return status;
-   }
+	/**
+	 * Create a empty result.<br/>
+	 * <br/>
+	 * Start time is set to Current Milliseconds.
+	 */
+	public TestResult() {
+		this(null);
+	}
 
-   public void setStatus(Status status)
-   {
-      this.status = status;
-   }
-   
-   /**
-    * If the test failed, the exception that was thrown. It does not need to be
-    * the root cause.
-    */
-   public Throwable getThrowable() 
-   {
-      return throwable;
-   }
-   
-   public void setThrowable(Throwable throwable)
-   {
-      this.throwable = throwable;
-   }
-   
-   /**
-    * Set the start time of the test.
-    * 
-    * @param start Start time in milliseconds
-    */
-   public void setStart(long start)
-   {
-      this.start = start;
-   }
-   
-   /**
-    * Get the start time.
-    * 
-    * @return Start time in milliseconds
-    */
-   public long getStart()
-   {
-      return start;
-   }
-   
-   /**
-    * Set the end time of the test.
-    * 
-    * @param End time in milliseconds
-    */
-   public void setEnd(long end)
-   {
-      this.end = end;
-   }
-   
-   /**
-    * Get the end time.
-    * 
-    * @return End time in milliseconds
-    */
-   public long getEnd()
-   {
-      return end;
-   }
+	/**
+	 * Create a new TestResult.<br/>
+	 * <br/>
+	 * Start time is set to Current Milliseconds.
+	 * 
+	 * @param status
+	 *            The result status.
+	 */
+	public TestResult(Status status) {
+		this(status, null);
+	}
+
+	/**
+	 * Create a new TestResult.<br/>
+	 * <br/>
+	 * Start time is set to Current Milliseconds.
+	 * 
+	 * @param status
+	 *            The result status.
+	 * @param throwable
+	 *            thrown exception if any
+	 */
+	public TestResult(Status status, Throwable throwable) {
+		this.status = status;		
+		setThrowable(throwable);
+
+		this.start = System.currentTimeMillis();
+	}
+
+	/**
+	 * Get the status of this test
+	 */
+	public Status getStatus() {
+		return status;
+	}
+
+	public void setStatus(Status status) {
+		this.status = status;
+	}
+
+	/**
+	 * If the test failed, the exception that was thrown. It does not need to be
+	 * the root cause.
+	 */
+	public Throwable getThrowable() {
+		if (throwable == null) {
+			if (exceptionProxy != null) {
+				throwable = exceptionProxy.createException();	
+			}			
+		}
+		return throwable;
+	}
+
+	public void setThrowable(Throwable throwable) {
+		this.throwable = throwable;		
+		this.exceptionProxy = ExceptionProxy.createForException(throwable);
+	}
+
+	/**
+	 * Set the start time of the test.
+	 * 
+	 * @param start
+	 *            Start time in milliseconds
+	 */
+	public void setStart(long start) {
+		this.start = start;
+	}
+
+	/**
+	 * Get the start time.
+	 * 
+	 * @return Start time in milliseconds
+	 */
+	public long getStart() {
+		return start;
+	}
+
+	/**
+	 * Set the end time of the test.
+	 * 
+	 * @param End
+	 *            time in milliseconds
+	 */
+	public void setEnd(long end) {
+		this.end = end;
+	}
+
+	/**
+	 * Get the end time.
+	 * 
+	 * @return End time in milliseconds
+	 */
+	public long getEnd() {
+		return end;
+	}
+
+	public ExceptionProxy getExceptionProxy() {
+		
+		return exceptionProxy;
+	}	
 }


### PR DESCRIPTION
Pull request for this fix for issue ARQ299 (Exception proxying)

When the exception is set in the test result it is proxied and eventually serialized. On the client side, the exception is re-constructed from the serializable proxy.

 In some cases, we cannot reconstruct the exception (for example, faces exceptions that need a faces context in the constructor). For those, we return a common arquillian exception proxy  exception containing the type of the original exception and the message.
