### PR TITLE
Jetty7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+containers/resin4-embedded/
+extensions/performance/arq-perf/
+resin-data/
+*.iml
+*.iws
+*.ipr
+.idea
 .project
 .settings/
 .classpath

--- a/containers/jetty-embedded-7/src/main/java/org/jboss/arquillian/container/jetty/embedded_7/JettyEmbeddedConfiguration.java
+++ b/containers/jetty-embedded-7/src/main/java/org/jboss/arquillian/container/jetty/embedded_7/JettyEmbeddedConfiguration.java
@@ -24,6 +24,7 @@ import org.jboss.arquillian.spi.ContainerProfile;
  * the Jetty Embedded 7.x and 8.x containers.
  *
  * @author Dan Allen
+ * @author Ales Justin
  * @version $Revision: $
  */
 public class JettyEmbeddedConfiguration implements ContainerConfiguration
@@ -33,6 +34,8 @@ public class JettyEmbeddedConfiguration implements ContainerConfiguration
    private int bindHttpPort = 9090;
 
    private boolean jettyPlus = true;
+
+   private String configurationClasses;
 
    public ContainerProfile getContainerProfile()
    {
@@ -67,5 +70,15 @@ public class JettyEmbeddedConfiguration implements ContainerConfiguration
    public void setJettyPlus(boolean jettyPlus)
    {
       this.jettyPlus = jettyPlus;
+   }
+
+   public String getConfigurationClasses()
+   {
+      return configurationClasses;
+   }
+
+   public void setConfigurationClasses(String configurationClasses)
+   {
+      this.configurationClasses = configurationClasses;
    }
 }

--- a/containers/jetty-embedded-7/src/main/java/org/jboss/arquillian/container/jetty/embedded_7/JettyEmbeddedContainer.java
+++ b/containers/jetty-embedded-7/src/main/java/org/jboss/arquillian/container/jetty/embedded_7/JettyEmbeddedContainer.java
@@ -45,6 +45,7 @@ import org.jboss.shrinkwrap.jetty_7.api.ShrinkWrapWebAppContext;
  * running in-container. However, the container is still configured properly during setup.</p>
  *
  * @author Dan Allen
+ * @author Ales Justin
  * @version $Revision: $
  */
 public class JettyEmbeddedContainer implements DeployableContainer
@@ -114,9 +115,16 @@ public class JettyEmbeddedContainer implements DeployableContainer
       try 
       {
          WebAppContext wctx = archive.as(ShrinkWrapWebAppContext.class);
-         // Jetty plus is required to support in-container invocation and enrichment
-         if (containerConfig.isJettyPlus())
+         // explicit configuration classes, as they have changed between jetty7 minor versions
+         String configurationClasses = containerConfig.getConfigurationClasses();
+         if (configurationClasses != null && configurationClasses.trim().length() > 0)
          {
+            String[] classes = configurationClasses.split(",");
+            wctx.setConfigurationClasses(classes);
+         }
+         else if (containerConfig.isJettyPlus())
+         {
+            // Jetty plus is required to support in-container invocation and enrichment
             wctx.setConfigurationClasses(JETTY_PLUS_CONFIGURATION_CLASSES);
          }
          // possible configuration parameters


### PR DESCRIPTION
Some Configuration classes names have changed in between minor Jetty versions.
This way we can still configure the old / new classes.
