### PR TITLE
Arq 391

### DIFF
--- a/containers/openejb-embedded-3.1/pom.xml
+++ b/containers/openejb-embedded-3.1/pom.xml
@@ -41,6 +41,12 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.jboss.arquillian</groupId>
+			<artifactId>arquillian-impl-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- 
     External Projects
      -->
@@ -71,7 +77,6 @@
 			<artifactId>javax.inject</artifactId>
 			<scope>provided</scope>
 		</dependency>
-
 	</dependencies>
 </project>
 

--- a/containers/openejb-embedded-3.1/src/main/java/org/jboss/arquillian/container/openejb/embedded_3_1/OpenEJBProfile.java
+++ b/containers/openejb-embedded-3.1/src/main/java/org/jboss/arquillian/container/openejb/embedded_3_1/OpenEJBProfile.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc. and/or its affiliates, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.arquillian.container.openejb.embedded_3_1;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.jboss.arquillian.impl.execution.AfterLifecycleEventExecuter;
+import org.jboss.arquillian.impl.execution.BeforeLifecycleEventExecuter;
+import org.jboss.arquillian.spi.Profile;
+
+/**
+ * This profile extends the CLIENT profile to include extensions
+ * that are normally only for in-container use.  Since OpenEJB
+ * is embedded, we need a combination of the standard extensions
+ * for client and in-container.
+ * 
+ * @author David Allen
+ *
+ */
+public class OpenEJBProfile implements Profile
+{
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public Collection<Class<?>> getClientProfile()
+   {
+      // Add the Before/After methods executors to the client profile
+      return Arrays.asList(
+            AfterLifecycleEventExecuter.class,
+            BeforeLifecycleEventExecuter.class
+      );
+   }
+
+   @Override
+   public Collection<Class<?>> getContainerProfile()
+   {
+      // Nothing to add to the container profile
+      return Collections.EMPTY_LIST;
+   }
+
+}

--- a/containers/openejb-embedded-3.1/src/main/resources/META-INF/services/org.jboss.arquillian.spi.Profile
+++ b/containers/openejb-embedded-3.1/src/main/resources/META-INF/services/org.jboss.arquillian.spi.Profile
@@ -1,0 +1,1 @@
+org.jboss.arquillian.container.openejb.embedded_3_1.OpenEJBProfile

--- a/containers/openejb-embedded-3.1/src/test/java/org/jboss/arquillian/container/openejb/embedded_3_1/BeforeAfterTest.java
+++ b/containers/openejb-embedded-3.1/src/test/java/org/jboss/arquillian/container/openejb/embedded_3_1/BeforeAfterTest.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc. and/or its affiliates, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.arquillian.container.openejb.embedded_3_1;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.openejb.embedded_3_1.ejb.EchoBean;
+import org.jboss.arquillian.container.openejb.embedded_3_1.ejb.EchoLocalBusiness;
+import org.jboss.arquillian.container.openejb.embedded_3_1.ejb.SimpleBean;
+import org.jboss.arquillian.container.openejb.embedded_3_1.ejb.SimpleLocalBusiness;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests the execution of BeforeClass and Before
+ * annotated methods.  This is essentially testing that the profiles
+ * are setup correctly for OpenEJB.
+ * 
+ * @author David Allen
+ *
+ */
+@RunWith(Arquillian.class)
+public class BeforeAfterTest
+{
+   //-------------------------------------------------------------------------------------||
+   // Instance Members -------------------------------------------------------------------||
+   //-------------------------------------------------------------------------------------||
+
+   /**
+    * Define the deployment
+    */
+   @Deployment
+   public static JavaArchive createDeployment()
+   {
+      return ShrinkWrap.create(JavaArchive.class, "test.jar").addClasses(EchoLocalBusiness.class, EchoBean.class, BeforeAfterTest.class);
+   }
+
+   private static boolean beforeClassExecuted = false;
+   private boolean beforeExecuted = false;
+   
+   @BeforeClass
+   public static void beforeClass()
+   {
+      beforeClassExecuted = true;
+   }
+   
+   @Before
+   public void before()
+   {
+      beforeExecuted = true;
+   }
+   
+   @Test
+   public void testAllBeforeMethodsExecuted()
+   {
+      Assert.assertTrue(beforeClassExecuted);
+      Assert.assertTrue(beforeExecuted);
+   }
+}


### PR DESCRIPTION
Fixes the Before/After method problem for the OpenEJB embedded container.  Added Profile which adds the same executors for this purpose as in the ArquillianProfile.getContainerProfile().
