### PR TITLE
ARQ-418 Arquillian container configuration reference mistakes

### DIFF
--- a/doc/reference/src/main/docbook/en-US/container_weld-se-embedded-1.1.xml
+++ b/doc/reference/src/main/docbook/en-US/container_weld-se-embedded-1.1.xml
@@ -106,7 +106,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.jboss.arquillian.container</groupId>
-			<artifactId>arquillian-weld-se-embedded-1</artifactId>
+			<artifactId>arquillian-weld-se-embedded-1.1</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
@@ -117,6 +117,12 @@
 			<groupId>org.jboss.weld</groupId>
 			<artifactId>weld-api</artifactId>
 		</dependency>
+                <dependency>
+                        <groupId>org.glassfish.web</groupId>
+                        <artifactId>el-impl</artifactId>
+                        <version>2.2</version>
+                        <scope>runtime</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>

--- a/doc/reference/src/main/docbook/en-US/container_weld-se-embedded-1.xml
+++ b/doc/reference/src/main/docbook/en-US/container_weld-se-embedded-1.xml
@@ -117,6 +117,12 @@
 			<groupId>org.jboss.weld</groupId>
 			<artifactId>weld-api</artifactId>
 		</dependency>
+                <dependency>
+                        <groupId>org.glassfish.web</groupId>
+                        <artifactId>el-impl</artifactId>
+                        <version>2.2</version>
+                        <scope>runtime</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>


### PR DESCRIPTION
Fixed Maven profile for Weld SE 1.0 and 1.1. (ARQ-418)

This documentation: http://docs.jboss.org/arquillian/reference/latest/en-US/html/container.reference.html#container.weld-se-embedded-1

Weld SE Embedded 1.0 and 1.1 configuration incomplete, is missing a dependency:

<dependency>
                    <groupId>org.glassfish.web</groupId>
                    <artifactId>el-impl</artifactId>
                    <version>2.2</version>
                    <scope>runtime</scope>
                </dependency>
Otherwise this will occur:

java.lang.NoClassDefFoundError: javax/el/ExpressionFactory
    at org.jboss.weld.bootstrap.WeldBootstrap.startContainer(WeldBootstrap.java:277)
    at org.jboss.arquillian.container.weld.se.embedded_1.WeldSEContainer.deploy(WeldSEContainer.java:131)
    at org.jboss.arquillian.impl.client.container.ContainerDeployController$3.call(ContainerDeployController.java:141)
    at org.jboss.arquillian.impl.client.container.ContainerDeployController$3.call(ContainerDeployController.java:115)
    at org.jboss.arquillian.impl.client.container.ContainerDeployController.executeOperation(ContainerDeployController.java:226)
    at org.jboss.arquillian.impl.client.container.ContainerDeployController.deploy(ContainerDeployController.java:114)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.arquillian.impl.core.ObserverImpl.invoke(ObserverImpl.java:90)
    at org.jboss.arquillian.impl.core.EventContextImpl.invokeObservers(EventContextImpl.java:98)
    at org.jboss.arquillian.impl.core.EventContextImpl.proceed(EventContextImpl.java:80)
    at org.jboss.arquillian.impl.client.ContainerDeploymentContextHandler.createDeploymentContext(ContainerDeploymentContextHandler.java:100)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.arquillian.impl.core.ObserverImpl.invoke(ObserverImpl.java:90)
    at org.jboss.arquillian.impl.core.EventContextImpl.proceed(EventContextImpl.java:87)
    at org.jboss.arquillian.impl.client.ContainerDeploymentContextHandler.createContainerContext(ContainerDeploymentContextHandler.java:78)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.arquillian.impl.core.ObserverImpl.invoke(ObserverImpl.java:90)
    at org.jboss.arquillian.impl.core.EventContextImpl.proceed(EventContextImpl.java:87)
    at org.jboss.arquillian.impl.client.container.DeploymentExceptionHandler.verifyExpectedExceptionDuringDeploy(DeploymentExceptionHandler.java:51)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.arquillian.impl.core.ObserverImpl.invoke(ObserverImpl.java:90)
    at org.jboss.arquillian.impl.core.EventContextImpl.proceed(EventContextImpl.java:87)
    at org.jboss.arquillian.impl.core.ManagerImpl.fire(ManagerImpl.java:126)
    at org.jboss.arquillian.impl.core.ManagerImpl.fire(ManagerImpl.java:106)
    at org.jboss.arquillian.impl.core.EventImpl.fire(EventImpl.java:67)
    at org.jboss.arquillian.impl.client.container.ContainerDeployController$1.perform(ContainerDeployController.java:86)
    at org.jboss.arquillian.impl.client.container.ContainerDeployController$1.perform(ContainerDeployController.java:79)
    at org.jboss.arquillian.impl.client.container.ContainerDeployController.forEachManagedDeployment(ContainerDeployController.java:217)
    at org.jboss.arquillian.impl.client.container.ContainerDeployController.deployManaged(ContainerDeployController.java:78)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.arquillian.impl.core.ObserverImpl.invoke(ObserverImpl.java:90)
    at org.jboss.arquillian.impl.core.EventContextImpl.invokeObservers(EventContextImpl.java:98)
    at org.jboss.arquillian.impl.core.EventContextImpl.proceed(EventContextImpl.java:80)
    at org.jboss.arquillian.impl.core.ManagerImpl.fire(ManagerImpl.java:126)
    at org.jboss.arquillian.impl.core.ManagerImpl.fire(ManagerImpl.java:106)
    at org.jboss.arquillian.impl.core.EventImpl.fire(EventImpl.java:67)
    at org.jboss.arquillian.impl.client.ContainerEventController.execute(ContainerEventController.java:69)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.arquillian.impl.core.ObserverImpl.invoke(ObserverImpl.java:90)
    at org.jboss.arquillian.impl.core.EventContextImpl.invokeObservers(EventContextImpl.java:98)
    at org.jboss.arquillian.impl.core.EventContextImpl.proceed(EventContextImpl.java:80)
    at org.jboss.arquillian.impl.TestContextHandler.createClassContext(TestContextHandler.java:68)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.arquillian.impl.core.ObserverImpl.invoke(ObserverImpl.java:90)
    at org.jboss.arquillian.impl.core.EventContextImpl.proceed(EventContextImpl.java:87)
    at org.jboss.arquillian.impl.TestContextHandler.createSuiteContext(TestContextHandler.java:54)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.jboss.arquillian.impl.core.ObserverImpl.invoke(ObserverImpl.java:90)
    at org.jboss.arquillian.impl.core.EventContextImpl.proceed(EventContextImpl.java:87)
    at org.jboss.arquillian.impl.core.ManagerImpl.fire(ManagerImpl.java:126)
    at org.jboss.arquillian.impl.core.ManagerImpl.fire(ManagerImpl.java:106)
    at org.jboss.arquillian.impl.EventTestRunnerAdaptor.beforeClass(EventTestRunnerAdaptor.java:70)
    at org.jboss.arquillian.junit.Arquillian$2.evaluate(Arquillian.java:170)
    at org.jboss.arquillian.junit.Arquillian.multiExecute(Arquillian.java:303)
    at org.jboss.arquillian.junit.Arquillian.access$300(Arquillian.java:45)
    at org.jboss.arquillian.junit.Arquillian$3.evaluate(Arquillian.java:187)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:236)
    at org.jboss.arquillian.junit.Arquillian.run(Arquillian.java:127)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:49)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:467)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:197)
Caused by: java.lang.ClassNotFoundException: javax.el.ExpressionFactory
    at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:307)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:301)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:248)
    ... 88 more
Weld SE 1.1 configuration is wrong:

<profile>
    <id>weld-se-embedded-11</id>
    <dependencies>
        <dependency>
            <groupId>org.jboss.arquillian.container</groupId>
            <artifactId>arquillian-weld-se-embedded-1</artifactId>
            <version>1.0.0.Alpha5</version>
        </dependency>
Should be:

<artifactId>arquillian-weld-se-embedded-1.1</artifactId>
